### PR TITLE
Noetic and Python3 Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,7 @@ catkin_package(
     ackermann_msgs
   DEPENDS
 )
+
+catkin_install_python(PROGRAMS scripts/joyop.py scripts/keyop.py
+	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+	)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ eg.3 `rosrun ackermann_drive_teleop keyop.py 0.5 0.8 ack_cmd`
 + Use the "up", "down" arrow keys to control speed, "left" and "right" arrow keys to control the steering angle,  
   space to brake and tab to reset the steering angle.  
 
+####  Running on noetic
+`cd $(python3 -m site --user-site)`
+Then make a file called `thread.py` with the following contents:
+`from _thread import *
+__all__ = ("error", "LockType", "start_new_thread", "interrupt_main", "exit", "allocate_lock", "get_ident", "stack_size", "acquire", "release", "locked")`
+
+Then `cd` into the catkin workspace and make the workspace. 
+
 ##### ackermann_drive_joyop
 + Run the teleoperation script, as well as the joy node using the following command:  
 `roslaunch ackermann_drive_teleop ackermann_drive_joyop.launch`  

--- a/README.md
+++ b/README.md
@@ -14,14 +14,6 @@ eg.3 `rosrun ackermann_drive_teleop keyop.py 0.5 0.8 ack_cmd`
 + Use the "up", "down" arrow keys to control speed, "left" and "right" arrow keys to control the steering angle,  
   space to brake and tab to reset the steering angle.  
 
-####  Running on noetic
-`cd $(python3 -m site --user-site)`
-Then make a file called `thread.py` with the following contents:
-`from _thread import *
-__all__ = ("error", "LockType", "start_new_thread", "interrupt_main", "exit", "allocate_lock", "get_ident", "stack_size", "acquire", "release", "locked")`
-
-Then `cd` into the catkin workspace and make the workspace. 
-
 ##### ackermann_drive_joyop
 + Run the teleoperation script, as well as the joy node using the following command:  
 `roslaunch ackermann_drive_teleop ackermann_drive_joyop.launch`  

--- a/scripts/keyop.py
+++ b/scripts/keyop.py
@@ -15,7 +15,12 @@ import rospy
 from ackermann_msgs.msg import AckermannDriveStamped
 from std_msgs.msg import Float64
 import sys, select, termios, tty
-import thread
+
+try:
+    import thread
+except ImportError:
+    #for python3 compatability
+    import _thread
 from numpy import clip
 
 control_keys = {


### PR DESCRIPTION
- Added Catkin install for python

- Added Try Catch block around thread module

Overall these changes were minor, and backwards-compatible, but needed to get this package working on ros-noetic and python3. 